### PR TITLE
(SIMP-2045) Added default rsyslog lastaction logic

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,5 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check
---no-80chars-check
+--no-140chars-check
 --no-trailing_comma-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Apr 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.1.0-0
+- Added lastaction logic to logrotate::rule.
+
 * Fri Dec 16 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Updated for Puppet 4
 - Renamed the `logrotate::add` defined type to `logrotate::rule`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,19 +40,27 @@
 #
 #   * Overrides the ``maxsize`` setting
 #
+# @param logger_service
+#   The service that controls system logging
+#
+#   * This is used by the ``logrotate::rule`` define to note the name of the
+#     service to be restarted if, and only if, the default lastaction is
+#     enabled.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class logrotate (
-  Enum['daily','weekly','monthly','yearly'] $rotate_period = 'weekly',
-  Integer[0]                                $rotate        = 4,
-  Boolean                                   $create        = true,
-  Boolean                                   $compress      = true,
-  Array[Stdlib::Absolutepath]               $include_dirs  = [],
-  Boolean                                   $manage_wtmp   = true,
-  Boolean                                   $dateext       = true,
-  String                                    $dateformat    = '-%Y%m%d.%s',
-  Optional[Pattern['^\d+(k|M|G)?$']]        $maxsize       = undef,
-  Optional[Pattern['^\d+(k|M|G)?$']]        $minsize       = undef
+  Enum['daily','weekly','monthly','yearly'] $rotate_period  = 'weekly',
+  Integer[0]                                $rotate         = 4,
+  Boolean                                   $create         = true,
+  Boolean                                   $compress       = true,
+  Array[Stdlib::Absolutepath]               $include_dirs   = [],
+  Boolean                                   $manage_wtmp    = true,
+  Boolean                                   $dateext        = true,
+  String                                    $dateformat     = '-%Y%m%d.%s',
+  Optional[Pattern['^\d+(k|M|G)?$']]        $maxsize        = undef,
+  Optional[Pattern['^\d+(k|M|G)?$']]        $minsize        = undef,
+  String                                    $logger_service = 'rsyslog'
 ) {
   package { 'logrotate': ensure => 'latest' }
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -44,14 +44,16 @@
 # @param firstaction
 # @param lastaction
 #
-# @param logger_service
-#   The name of the service which will be restarted as a lastaction, if
-#   no $lastaction is passed, and $lastaction_restart_logger is true.
-#   Defaults to rsyslog.
-#
 # @param lastaction_restart_logger
-#   If no $lastaction is passed, this will toggle restarting $logger_service
-#   as a lastaction.
+#   Restart ``$logger_service`` as a logrotate ``lastaction``
+#
+#   * Has no effect if ``$lastaction`` is set
+#
+# @param logger_service
+#   The name of the service which will be restarted as a logrotate ``lastaction``
+#
+#   * NOTE: This will default to ``rsyslog`` unless otherwise specified either
+#     in the call to the define or as ``logrotate::logger_service``
 #
 # @param rotate
 # @param size
@@ -88,8 +90,8 @@ define logrotate::rule (
   Optional[String]                                    $prerotate                 = undef,
   Optional[String]                                    $firstaction               = undef,
   Optional[String]                                    $lastaction                = undef,
-  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::rule::logger_service', 'default_value' => 'rsyslog'}),
   Boolean                                             $lastaction_restart_logger = false,
+  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::logger_service', 'default_value' => 'rsyslog'}),
   Integer[0]                                          $rotate                    = 4,
   Optional[Integer[0]]                                $size                      = undef,
   Boolean                                             $sharedscripts             = true,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -91,7 +91,7 @@ define logrotate::rule (
   Optional[String]                                    $firstaction               = undef,
   Optional[String]                                    $lastaction                = undef,
   Boolean                                             $lastaction_restart_logger = false,
-  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::logger_service', 'default_value' => 'rsyslog'}),
+  Optional[String]                                    $logger_service            = simplib::lookup('logrotate::logger_service', {'default_value' => 'rsyslog'}),
   Integer[0]                                          $rotate                    = 4,
   Optional[Integer[0]]                                $size                      = undef,
   Boolean                                             $sharedscripts             = true,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -88,7 +88,7 @@ define logrotate::rule (
   Optional[String]                                    $prerotate                 = undef,
   Optional[String]                                    $firstaction               = undef,
   Optional[String]                                    $lastaction                = undef,
-  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::rule::logger_service', "default_value" => 'rsyslog'}),
+  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::rule::logger_service', 'default_value' => 'rsyslog'}),
   Boolean                                             $lastaction_restart_logger = false,
   Integer[0]                                          $rotate                    = 4,
   Optional[Integer[0]]                                $size                      = undef,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -43,6 +43,16 @@
 # @param prerotate
 # @param firstaction
 # @param lastaction
+#
+# @param logger_service
+#   The name of the service which will be restarted as a lastaction, if
+#   no $lastaction is passed, and $lastaction_restart_logger is true.
+#   Defaults to rsyslog.
+#
+# @param lastaction_restart_logger
+#   If no $lastaction is passed, this will toggle restarting $logger_service
+#   as a lastaction.
+#
 # @param rotate
 # @param size
 # @param sharedscripts
@@ -53,37 +63,55 @@
 #
 define logrotate::rule (
   Array[String]                                       $log_files,
-  Boolean                                             $compress        = true,
-  Optional[String]                                    $compresscmd     = undef,
-  Optional[String]                                    $uncompresscmd   = undef,
-  Optional[String]                                    $compressext     = undef,
-  Optional[String]                                    $compressoptions = undef,
-  Boolean                                             $copy            = false,
-  Boolean                                             $copytruncate    = false,
-  Pattern['\d{4} .+ .+']                              $create          = '0640 root root',
-  Optional[Enum['daily','weekly','monthly','yearly']] $rotate_period   = undef,
-  Boolean                                             $dateext         = true,
-  String                                              $dateformat      = '-%Y%m%d.%s',
-  Optional[Boolean]                                   $delaycompress   = undef,
-  Optional[String]                                    $extension       = undef,
-  Boolean                                             $ifempty         = false,
-  Array[String]                                       $ext_include     = [],
-  Optional[Simplib::EmailAddress]                     $mail            = undef,
-  Boolean                                             $maillast        = true,
-  Optional[Integer[0]]                                $maxage          = undef,
-  Optional[Integer[0]]                                $minsize         = undef,
-  Boolean                                             $missingok       = false,
-  Optional[Stdlib::Absolutepath]                      $olddir          = undef,
-  Optional[String]                                    $postrotate      = undef,
-  Optional[String]                                    $prerotate       = undef,
-  Optional[String]                                    $firstaction     = undef,
-  Optional[String]                                    $lastaction      = undef,
-  Integer[0]                                          $rotate          = 4,
-  Optional[Integer[0]]                                $size            = undef,
-  Boolean                                             $sharedscripts   = true,
-  Integer[0]                                          $start           = 1,
-  Array[String]                                       $tabooext        = []
+  Boolean                                             $compress                  = true,
+  Optional[String]                                    $compresscmd               = undef,
+  Optional[String]                                    $uncompresscmd             = undef,
+  Optional[String]                                    $compressext               = undef,
+  Optional[String]                                    $compressoptions           = undef,
+  Boolean                                             $copy                      = false,
+  Boolean                                             $copytruncate              = false,
+  Pattern['\d{4} .+ .+']                              $create                    = '0640 root root',
+  Optional[Enum['daily','weekly','monthly','yearly']] $rotate_period             = undef,
+  Boolean                                             $dateext                   = true,
+  String                                              $dateformat                = '-%Y%m%d.%s',
+  Optional[Boolean]                                   $delaycompress             = undef,
+  Optional[String]                                    $extension                 = undef,
+  Boolean                                             $ifempty                   = false,
+  Array[String]                                       $ext_include               = [],
+  Optional[Simplib::EmailAddress]                     $mail                      = undef,
+  Boolean                                             $maillast                  = true,
+  Optional[Integer[0]]                                $maxage                    = undef,
+  Optional[Integer[0]]                                $minsize                   = undef,
+  Boolean                                             $missingok                 = false,
+  Optional[Stdlib::Absolutepath]                      $olddir                    = undef,
+  Optional[String]                                    $postrotate                = undef,
+  Optional[String]                                    $prerotate                 = undef,
+  Optional[String]                                    $firstaction               = undef,
+  Optional[String]                                    $lastaction                = undef,
+  Optional[String]                                    $logger_service            = lookup({'name' => 'logrotate::rule::logger_service', "default_value" => 'rsyslog'}),
+  Boolean                                             $lastaction_restart_logger = false,
+  Integer[0]                                          $rotate                    = 4,
+  Optional[Integer[0]]                                $size                      = undef,
+  Boolean                                             $sharedscripts             = true,
+  Integer[0]                                          $start                     = 1,
+  Array[String]                                       $tabooext                  = []
 ) {
+
+  # Use the provided lastaction.  If none provided, determine if the
+  # logger_service should be restarted.
+  if !$lastaction {
+    if $lastaction_restart_logger {
+      $_restartcmd = ('systemd' in $facts['init_systems']) ? {
+        true    => "/usr/bin/systemctl restart ${logger_service}",
+        default => "/sbin/service ${logger_service} restart"
+      }
+      $_lastaction = "${_restartcmd} > /dev/null 2>&1 || true"
+    }
+  }
+  else {
+    $_lastaction = $lastaction
+  }
+
   file { "/etc/logrotate.d/${name}":
     owner   => 'root',
     group   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -41,10 +41,6 @@
     {
       "name": "puppet",
       "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-logrotate",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "configure SIMP logrotate",
   "license": "Apache-2.0",

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -4,16 +4,58 @@ describe 'logrotate::rule' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) { facts }
 
         let(:title) {'test_logrotate_title'}
+        let(:facts) { facts }
 
-        let(:params) {{
-          :log_files => ['test1.log', 'test2.log']
-        }}
+        context 'without a lastaction specified and lastaction_restart_logger = false' do
+          let(:params) {{
+            :log_files => ['test1.log', 'test2.log']
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
+          it { is_expected.to_not create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction/) }
+        end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
+        context 'without a lastaction specified and lastaction_restart_logger = true' do
+          let(:params) {{
+            :log_files                 => ['test1.log', 'test2.log'],
+            :lastaction_restart_logger => true
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
+          if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
+            if (facts[:operatingsystemmajrelease].to_s >= '7')
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/usr\/bin\/systemctl restart rsyslog/) }
+            else
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/sbin\/service rsyslog restart/) }
+            end
+          end
+        end
+
+        context 'with an alternate logger specified' do
+          let(:params) {{
+            :log_files                 => ['test1.log', 'test2.log'],
+            :lastaction_restart_logger => true
+          }}
+          let(:hieradata) { 'alternate_logger' }
+          if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
+            if (facts[:operatingsystemmajrelease].to_s >= '7')
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/usr\/bin\/systemctl restart syslog/) }
+            else
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/sbin\/service syslog restart/) }
+            end
+          end
+        end
+
+        context 'with a lastaction specified' do
+          let(:params) {{
+            :log_files   => ['test1.log', 'test2.log'],
+            :lastaction  => 'this is a lastaction'
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*this is a lastaction/) }
+        end
       end
     end
   end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -26,9 +26,9 @@ describe 'logrotate::rule' do
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
             if (facts[:operatingsystemmajrelease].to_s >= '7')
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/usr\/bin\/systemctl restart rsyslog/) }
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart rsyslog/m) }
             else
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/sbin\/service rsyslog restart/) }
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service rsyslog restart/m) }
             end
           end
         end
@@ -41,9 +41,9 @@ describe 'logrotate::rule' do
           let(:hieradata) { 'alternate_logger' }
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
             if (facts[:operatingsystemmajrelease].to_s >= '7')
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/usr\/bin\/systemctl restart syslog/) }
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart syslog/m) }
             else
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*\/sbin\/service syslog restart/) }
+              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service syslog restart/m) }
             end
           end
         end
@@ -54,7 +54,7 @@ describe 'logrotate::rule' do
             :lastaction  => 'this is a lastaction'
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n.*this is a lastaction/) }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
         end
       end
     end

--- a/spec/fixtures/hieradata/alternate_logger.yaml
+++ b/spec/fixtures/hieradata/alternate_logger.yaml
@@ -1,0 +1,2 @@
+---
+logrotate::rule::logger_service: 'syslog'

--- a/spec/fixtures/hieradata/alternate_logger.yaml
+++ b/spec/fixtures/hieradata/alternate_logger.yaml
@@ -1,2 +1,2 @@
 ---
-logrotate::rule::logger_service: 'syslog'
+logrotate::logger_service: 'syslog'

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -91,9 +91,9 @@
 <%= "\t\t#{@firstaction}" %>
     endscript
 <%  end -%>
-<%  if @lastaction -%>
+<%  if @_lastaction -%>
     lastaction
-<%= "\t\t#{@lastaction}" %>
+<%= "\t\t#{@_lastaction}" %>
     endscript
 <%  end -%>
     rotate <%= @rotate %>


### PR DESCRIPTION
- The logic to determine rsyslog-specific lastactions was spread
  throughout the code in the past, making maintenance difficult.
  It is now contained inside logrotate::rule.
- Flexibility has been added to lastaction.  Service calls are
  determined by facts and users can pass in any logging service
  they wish.

SIMP-2045 #comment Primary update to logrotate complete