### PR TITLE
(SIMP-3545) Logrotate: dateext option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 01 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.1-0
+- Updated the default settings in rule.pp to reflect those in init.pp
+- changed templates to add nodateext if dateext is set to false.
+
 * Thu Apr 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.1.0-0
 - Added lastaction logic to logrotate::rule.
 - Update puppet requirement and remove OBE pe requirement in metadata.json

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -65,7 +65,7 @@
 #
 define logrotate::rule (
   Array[String]                                       $log_files,
-  Boolean                                             $compress                  = true,
+  Boolean                                             $compress                  = $logrotate::compress,
   Optional[String]                                    $compresscmd               = undef,
   Optional[String]                                    $uncompresscmd             = undef,
   Optional[String]                                    $compressext               = undef,
@@ -74,7 +74,7 @@ define logrotate::rule (
   Boolean                                             $copytruncate              = false,
   Pattern['\d{4} .+ .+']                              $create                    = '0640 root root',
   Optional[Enum['daily','weekly','monthly','yearly']] $rotate_period             = undef,
-  Boolean                                             $dateext                   = true,
+  Boolean                                             $dateext                   = $logrotate::dateext,
   String                                              $dateformat                = '-%Y%m%d.%s',
   Optional[Boolean]                                   $delaycompress             = undef,
   Optional[String]                                    $extension                 = undef,
@@ -92,12 +92,14 @@ define logrotate::rule (
   Optional[String]                                    $lastaction                = undef,
   Boolean                                             $lastaction_restart_logger = false,
   Optional[String]                                    $logger_service            = simplib::lookup('logrotate::logger_service', {'default_value' => 'rsyslog'}),
-  Integer[0]                                          $rotate                    = 4,
+  Integer[0]                                          $rotate                    = $logrotate::rotate,
   Optional[Integer[0]]                                $size                      = undef,
   Boolean                                             $sharedscripts             = true,
   Integer[0]                                          $start                     = 1,
   Array[String]                                       $tabooext                  = []
 ) {
+
+  include '::logrotate'
 
   # Use the provided lastaction.  If none provided, determine if the
   # logger_service should be restarted.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-logrotate",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "configure SIMP logrotate",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,6 +11,14 @@ describe 'logrotate' do
         it { is_expected.to create_file('/etc/logrotate.conf').with_content(/weekly/) }
         it { is_expected.to create_file('/etc/logrotate.d').with_ensure('directory') }
         it { is_expected.to contain_package('logrotate').with_ensure('latest') }
+
+        context "dateext set to false" do
+          let(:params) {{
+            :dateext => false
+          }}
+
+          it { is_expected.to create_file('/etc/logrotate.conf').with_content(/nodateext/)}
+        end
       end
     end
   end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -6,6 +6,7 @@ describe 'logrotate::rule' do
       context "on #{os}" do
 
         let(:title) {'test_logrotate_title'}
+         let(:pre_condition) { 'include "logrotate"' }
         let(:facts) { facts }
 
         context 'without a lastaction specified and lastaction_restart_logger = false' do
@@ -55,6 +56,14 @@ describe 'logrotate::rule' do
           }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
+        end
+        context 'with dateext set to false' do
+          let(:params) {{
+            :log_files => ['test1.log', 'test2.log'],
+            :dateext   => false
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/nodateext\n/m) }
         end
       end
     end

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -41,6 +41,8 @@
 <%  if @dateext -%>
     dateext
     dateformat <%= @dateformat %>
+<%  else -%>
+    nodateext
 <%  end -%>
 <%  if @extension -%>
     extension <%= @extension %>

--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -12,6 +12,8 @@ compress
 <% if @dateext -%>
 dateext
 dateformat <%= @dateformat %>
+<%  else -%>
+nodateext
 <% end -%>
 <%
   (['/etc/logrotate.d'] + Array(@include_dirs)).flatten.each do |_dir|


### PR DESCRIPTION
- updated the templates to set nodateext if dateext
  is set to false
- updated rule define to use defaults in init where
  applicable.

SIMP-3545 #close
SIMP-3727 #close