### PR TITLE
(SIMP-3545) Logrotate dateext option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 01 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.1-0
+- Updated the default settings in rule.pp to reflect those in init.pp
+- changed templates to add nodateext if dateext is set to false.
+
 * Thu Apr 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.1.0-0
 - Added lastaction logic to logrotate::rule.
 - Update puppet requirement and remove OBE pe requirement in metadata.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Fri Sep 01 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.1-0
-- Updated the default settings in rule.pp to reflect those in init.pp
+- Updated the defaults  settings for compress, rotate and dateext in rule.pp
+  to pull values from init.pp. (They were hard coded to them before)
 - changed templates to add nodateext if dateext is set to false.
 
 * Thu Apr 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.1.0-0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,10 +15,13 @@
 # @param compress
 #   Compress the logs upon rotation
 #
+# @param configdir
+#   The primary directory for configuration files.
+#
 # @param include_dirs
 #   Directories to include in your logrotate configuration
 #
-#   * ``/etc/logrotate.d`` is always included
+#   * ``$logrotate::configdir`` is always included
 #
 # @param manage_wtmp
 #   Set to ``false`` if you do not want ``/var/log/wtmp`` to be managed by
@@ -40,6 +43,9 @@
 #
 #   * Overrides the ``maxsize`` setting
 #
+# @param package_ensure
+#   The ensure status of packages to be installed
+#
 # @param logger_service
 #   The service that controls system logging
 #
@@ -55,6 +61,7 @@ class logrotate (
   Boolean                                   $create         = true,
   Boolean                                   $compress       = true,
   Array[Stdlib::Absolutepath]               $include_dirs   = [],
+  Stdlib::Absolutepath                      $configdir      = '/etc/logrotate.d',
   Boolean                                   $manage_wtmp    = true,
   Boolean                                   $dateext        = true,
   String                                    $dateformat     = '-%Y%m%d.%s',
@@ -74,12 +81,10 @@ class logrotate (
     content => template("${module_name}/logrotate.conf.erb")
   }
 
-  if !defined(File['/etc/logrotate.d']) {
-    file { '/etc/logrotate.d':
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644'
-    }
+  file { "${configdir}":
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644'
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,9 +60,11 @@ class logrotate (
   String                                    $dateformat     = '-%Y%m%d.%s',
   Optional[Pattern['^\d+(k|M|G)?$']]        $maxsize        = undef,
   Optional[Pattern['^\d+(k|M|G)?$']]        $minsize        = undef,
+  String                                    $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String                                    $logger_service = 'rsyslog'
+
 ) {
-  package { 'logrotate': ensure => 'latest' }
+  package { 'logrotate': ensure => $package_ensure }
 
   file { '/etc/logrotate.conf':
     ensure  => 'file',
@@ -72,10 +74,12 @@ class logrotate (
     content => template("${module_name}/logrotate.conf.erb")
   }
 
-  file { '/etc/logrotate.d':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644'
+  if !defined(File['/etc/logrotate.d']) {
+    file { '/etc/logrotate.d':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644'
+    }
   }
 }

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -65,7 +65,7 @@
 #
 define logrotate::rule (
   Array[String]                                       $log_files,
-  Boolean                                             $compress                  = true,
+  Boolean                                             $compress                  = $logrotate::compress,
   Optional[String]                                    $compresscmd               = undef,
   Optional[String]                                    $uncompresscmd             = undef,
   Optional[String]                                    $compressext               = undef,
@@ -74,7 +74,7 @@ define logrotate::rule (
   Boolean                                             $copytruncate              = false,
   Pattern['\d{4} .+ .+']                              $create                    = '0640 root root',
   Optional[Enum['daily','weekly','monthly','yearly']] $rotate_period             = undef,
-  Boolean                                             $dateext                   = true,
+  Boolean                                             $dateext                   = $logrotate::dateext,
   String                                              $dateformat                = '-%Y%m%d.%s',
   Optional[Boolean]                                   $delaycompress             = undef,
   Optional[String]                                    $extension                 = undef,
@@ -92,12 +92,14 @@ define logrotate::rule (
   Optional[String]                                    $lastaction                = undef,
   Boolean                                             $lastaction_restart_logger = false,
   Optional[String]                                    $logger_service            = simplib::lookup('logrotate::logger_service', {'default_value' => 'rsyslog'}),
-  Integer[0]                                          $rotate                    = 4,
+  Integer[0]                                          $rotate                    = $logrotate::rotate,
   Optional[Integer[0]]                                $size                      = undef,
   Boolean                                             $sharedscripts             = true,
   Integer[0]                                          $start                     = 1,
   Array[String]                                       $tabooext                  = []
 ) {
+
+  include '::logrotate'
 
   # Use the provided lastaction.  If none provided, determine if the
   # logger_service should be restarted.

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -15,6 +15,7 @@
 #   The log file strings for all logs to be affected by this stanza
 #
 # @param compress
+#   If undefined it defaults to the setting in logrotate.
 # @param compresscmd
 # @param uncompresscmd
 # @param compressext
@@ -24,6 +25,9 @@
 # @param create
 # @param rotate_period
 # @param dateext
+#   If set to true log files will be rotated using a date extension.
+#   If false nodateext is set and rotated logs use a number extension.
+#   If undefined it defaults to the setting in logrotate
 # @param dateformat
 # @param delaycompress
 # @param extension
@@ -56,6 +60,8 @@
 #     in the call to the define or as ``logrotate::logger_service``
 #
 # @param rotate
+#   The number of old log files to keep.
+#   If undefined it defaults to the setting in logrotate
 # @param size
 # @param sharedscripts
 # @param start
@@ -101,15 +107,6 @@ define logrotate::rule (
 
   include '::logrotate'
 
-  if !defined(File['/etc/logrotate.d']) {
-    file { '/etc/logrotate.d':
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644'
-    }
-  }
-
   # Use the provided lastaction.  If none provided, determine if the
   # logger_service should be restarted.
   if !$lastaction {
@@ -137,7 +134,7 @@ define logrotate::rule (
     undef   => $logrotate::rotate,
     default => $rotate }
 
-  file { "/etc/logrotate.d/${name}":
+  file { "${logrotate::configdir}/${name}":
     owner   => 'root',
     group   => 'root',
     mode    => '0644',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-logrotate",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "configure SIMP logrotate",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,7 @@ describe 'logrotate' do
         it { is_expected.to create_class('logrotate') }
         it { is_expected.to create_file('/etc/logrotate.conf').with_content(/weekly/) }
         it { is_expected.to create_file('/etc/logrotate.d').with_ensure('directory') }
-        it { is_expected.to contain_package('logrotate').with_ensure('latest') }
+        it { is_expected.to contain_package('logrotate').with_ensure('installed') }
 
         context "dateext set to false" do
           let(:params) {{

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,6 +11,14 @@ describe 'logrotate' do
         it { is_expected.to create_file('/etc/logrotate.conf').with_content(/weekly/) }
         it { is_expected.to create_file('/etc/logrotate.d').with_ensure('directory') }
         it { is_expected.to contain_package('logrotate').with_ensure('latest') }
+
+        context "dateext set to false" do
+          let(:params) {{
+            :dateext => false
+          }}
+
+          it { is_expected.to create_file('/etc/logrotate.conf').with_content(/nodateext/)}
+        end
       end
     end
   end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -66,7 +66,7 @@ describe 'logrotate::rule' do
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*dateext\n/m) }
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*rotate\s+4\n/m) }
         end
-        context 'with dateext set to false' do
+        context 'with non default parameters' do
           let(:params) {{
             :log_files => ['test1.log', 'test2.log'],
             :dateext   => false,

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -6,7 +6,7 @@ describe 'logrotate::rule' do
       context "on #{os}" do
 
         let(:title) {'test_logrotate_title'}
-         let(:pre_condition) { 'include "logrotate"' }
+        let(:pre_condition) { 'include "logrotate"' }
         let(:facts) { facts }
 
         context 'without a lastaction specified and lastaction_restart_logger = false' do
@@ -57,13 +57,24 @@ describe 'logrotate::rule' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
         end
+        context 'with default params' do
+          let(:params) {{
+            :log_files => ['test1.log', 'test2.log'],
+          }}
+          let(:pre_condition) { 'include "logrotate"' }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*dateext\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*rotate\s+4\n/m) }
+        end
         context 'with dateext set to false' do
           let(:params) {{
             :log_files => ['test1.log', 'test2.log'],
-            :dateext   => false
+            :dateext   => false,
+            :rotate    => 5
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/nodateext\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*nodateext\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*rotate\s+5\n/m) }
         end
       end
     end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -6,6 +6,7 @@ describe 'logrotate::rule' do
       context "on #{os}" do
 
         let(:title) {'test_logrotate_title'}
+         let(:pre_condition) { 'include "logrotate"' }
         let(:facts) { facts }
 
         context 'without a lastaction specified and lastaction_restart_logger = false' do
@@ -55,6 +56,14 @@ describe 'logrotate::rule' do
           }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
+        end
+        context 'with dateext set to false' do
+          let(:params) {{
+            :log_files => ['test1.log', 'test2.log'],
+            :dateext   => false
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/nodateext\n/m) }
         end
       end
     end

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -2,7 +2,7 @@
 # Any changes that you make will be reverted on the next puppet run.
 
 <%  Array(@log_files).each do |_file| -%>"<%= _file %>" <% end -%> {
-<%  unless @compress -%>
+<%  unless @_compress -%>
     nocompress
 <%  else -%>
     compress
@@ -38,7 +38,7 @@
 <%  if @rotate_period -%>
     <%= @rotate_period %>
 <%  end -%>
-<%  if @dateext -%>
+<%  if @_dateext -%>
     dateext
     dateformat <%= @dateformat %>
 <%  else -%>
@@ -98,7 +98,7 @@
 <%= "\t\t#{@_lastaction}" %>
     endscript
 <%  end -%>
-    rotate <%= @rotate %>
+    rotate <%= @_rotate.to_s %>
 <%  if @size -%>
     size <%= @size %>
 <%  end -%>

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -41,6 +41,8 @@
 <%  if @dateext -%>
     dateext
     dateformat <%= @dateformat %>
+<%  else -%>
+    nodateext
 <%  end -%>
 <%  if @extension -%>
     extension <%= @extension %>

--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -12,6 +12,8 @@ compress
 <% if @dateext -%>
 dateext
 dateformat <%= @dateformat %>
+<%  else -%>
+nodateext
 <% end -%>
 <%
   (['/etc/logrotate.d'] + Array(@include_dirs)).flatten.each do |_dir|

--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -16,7 +16,7 @@ dateformat <%= @dateformat %>
 nodateext
 <% end -%>
 <%
-  (['/etc/logrotate.d'] + Array(@include_dirs)).flatten.each do |_dir|
+  ([@configdir] + Array(@include_dirs)).flatten.each do |_dir|
 -%>
 include <%= _dir %>
 <% end -%>


### PR DESCRIPTION
    - updated the templates to set nodateext if dateext
      is set to false
    - updated rule define to use defaults in init where
      applicable.
    - changed default package setting to install and used
      simp_options.
    
    SIMP-3545 #close
    SIMP-3727 #closeset variables in code not in params
