### PR TITLE
(SIMP-4979) Prioritize SIMP logrotate rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,213 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    # An attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
+
+.validation_checks: &validation_checks
+  script:
     - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
+    - bundle exec rake clean
+    - bundle exec puppet module build
+
+.spec_tests: &spec_tests
+  script:
     - bundle exec rake spec
 
-# For PE LTS Support
+stages:
+  - validation
+  - unit
+  - acceptance
+  - deploy
+
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
+# --------------------------------------
+pup4_7-validation:
+  stage: validation
+  tags:
     - docker
   image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
 
-acceptance-test: 
-  stage: test
-  tags: 
+pup4_7-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4_8-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_8-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4_10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5_3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5_3-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5_latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5_latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+
+# Acceptance tests
+# ==============================================================================
+default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default]
+
+default-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default]

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,6 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,84 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "meafmOkfHC+4XmBrXYQbQkrdgWhGhobn6W+GIqiNFqoPSwMYreKYviTNU89B6zHzisbdk7PWdrB8DVrkDlg5BHzuGC/M5GRC41p11I0ABwPeKxq0tSd4eDTdPizq623wqWnxJ/FpZLRf1YT95sZX7/qAvDawBpZb7R4Qo0IxcpAlB/N/5bsfyn+Q9rjYPhC1emq6Aw+P31OUuczz30r3ecE/i7CdbCGpB6rzTnC4mggRN0JuS2srbHS8mDTqX1LNGplLm6dQnAw3ygHqo57idNt8vHTJ9fiT5W/fJRk+VtrkVNT+HaIFr+HLK/On0g5TrD0x9mKwUoYKRe7yxU9HvQk5+/y8WUKcZYPs5l/pB1P/OiilkxHehSkSQwZHe2HnhQ4fGGkfDtwZ9F4vlaO8Z6e7Wl3DB2iyQQaiwvdxIxyruGKm7pi+VOBZ+4ZCysmYlKg7+yplhJmXUaVRY05Yr7D39EjyFPVTMBSqjO+UJeyYUkrMAa1WCGq6j/WOFnRxvMBNyVof1ix6jzEEWxR+mW14B0SQiDCP9tf5mIfvrmh9Dq1IKibRdSUrY6sl1dze6HUVPy0HlMhDskmGtp7Dq+eMU0wxCGOYatolA2AauDJ9cZwTad79FNDiC0Fg1vOyHgioHHs42ZcPFKWC2EV86FOmAVAo73/pqHKKsppVy5c="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: check
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+        - bundle exec rake lint
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "U9Nb1LWOThHtm4KAUghELRYsZX2aIVjne9POIORVqQcMdWHN3JdyoQoXvulfiBnWXsFZPZ1fgBMkeh+cOWdB5cCBUlIDnazodX0gyKvTK662ubG9Zb/XRSxd2jUHRqgVIHb6GhQYCyTByhL5jU92Yk8aziV7zow2+RQTirgWqyplWmLo2+1vnoSPOrQHkWzJ2E2O8kLnmAzfj4JwhLD6xXU1ehcaT9ZAiXh1vZ3Bs/bSWeeOFh8V++e6Ey64cCMVpy0Nj6tj0nH/z1S5nOJEWg2DlbuIV5Z1Ha2zgiXTNouIFMbaoOARoc3WADOb9RY3fLar6zgoZ1q/hnhOsESUPW38xeOwxzr/3owJKkOUIacBHc0wM1YxcEXxtmCUluchMBA3Rx+m9De8xQyzgFeEmlbnv5MlUkfwZiOgK9uKs5LcZFHSdG2sqzS3JJNci7JvN9/mDMf7kMH88laAc4QHmAb8ZKEfi/tGr9yWHGmsi6qO3+aMAiXf+Np2ULXBNmttkKKPp5S0gVSs8GSlhnLJUyKYuTyJ/4bXr1OuRg5DvXB5BSqb/8dvLjNWoy9KtEo6XPEl/wl11qJoWSx2FNKZTGs0jK8uzMbCWzPmr9JmrlC0VFB8IlxVExRku9DKPIYyf1YVYZlCcjol/OwAYGdY6ZEOYiCMKJKgCQQmqCIWfgc="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "U9Nb1LWOThHtm4KAUghELRYsZX2aIVjne9POIORVqQcMdWHN3JdyoQoXvulfiBnWXsFZPZ1fgBMkeh+cOWdB5cCBUlIDnazodX0gyKvTK662ubG9Zb/XRSxd2jUHRqgVIHb6GhQYCyTByhL5jU92Yk8aziV7zow2+RQTirgWqyplWmLo2+1vnoSPOrQHkWzJ2E2O8kLnmAzfj4JwhLD6xXU1ehcaT9ZAiXh1vZ3Bs/bSWeeOFh8V++e6Ey64cCMVpy0Nj6tj0nH/z1S5nOJEWg2DlbuIV5Z1Ha2zgiXTNouIFMbaoOARoc3WADOb9RY3fLar6zgoZ1q/hnhOsESUPW38xeOwxzr/3owJKkOUIacBHc0wM1YxcEXxtmCUluchMBA3Rx+m9De8xQyzgFeEmlbnv5MlUkfwZiOgK9uKs5LcZFHSdG2sqzS3JJNci7JvN9/mDMf7kMH88laAc4QHmAb8ZKEfi/tGr9yWHGmsi6qO3+aMAiXf+Np2ULXBNmttkKKPp5S0gVSs8GSlhnLJUyKYuTyJ/4bXr1OuRg5DvXB5BSqb/8dvLjNWoy9KtEo6XPEl/wl11qJoWSx2FNKZTGs0jK8uzMbCWzPmr9JmrlC0VFB8IlxVExRku9DKPIYyf1YVYZlCcjol/OwAYGdY6ZEOYiCMKJKgCQQmqCIWfgc="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "meafmOkfHC+4XmBrXYQbQkrdgWhGhobn6W+GIqiNFqoPSwMYreKYviTNU89B6zHzisbdk7PWdrB8DVrkDlg5BHzuGC/M5GRC41p11I0ABwPeKxq0tSd4eDTdPizq623wqWnxJ/FpZLRf1YT95sZX7/qAvDawBpZb7R4Qo0IxcpAlB/N/5bsfyn+Q9rjYPhC1emq6Aw+P31OUuczz30r3ecE/i7CdbCGpB6rzTnC4mggRN0JuS2srbHS8mDTqX1LNGplLm6dQnAw3ygHqo57idNt8vHTJ9fiT5W/fJRk+VtrkVNT+HaIFr+HLK/On0g5TrD0x9mKwUoYKRe7yxU9HvQk5+/y8WUKcZYPs5l/pB1P/OiilkxHehSkSQwZHe2HnhQ4fGGkfDtwZ9F4vlaO8Z6e7Wl3DB2iyQQaiwvdxIxyruGKm7pi+VOBZ+4ZCysmYlKg7+yplhJmXUaVRY05Yr7D39EjyFPVTMBSqjO+UJeyYUkrMAa1WCGq6j/WOFnRxvMBNyVof1ix6jzEEWxR+mW14B0SQiDCP9tf5mIfvrmh9Dq1IKibRdSUrY6sl1dze6HUVPy0HlMhDskmGtp7Dq+eMU0wxCGOYatolA2AauDJ9cZwTad79FNDiC0Fg1vOyHgioHHs42ZcPFKWC2EV86FOmAVAo73/pqHKKsppVy5c="
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Jul 02 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.0-0
+- Move SIMP-specific logrotate rules to a SIMP-managed configuration
+  directory, /etc/logrotate.simp.d, and ensure logrotate processes
+  that directory first. This ensures SIMP rules take priority, when
+  duplicate rules are specified.
+
 * Thu Nov 30 2017 Steven Pritchard <steven.pritchard@onyxpoint.com> - 6.1.2-0
 - Update README.md from puppet strings
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,25 +17,16 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'travish'
-  gem 'puppet-blacksmith'
-  gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
-
-  # `listen` is a dependency of `guard`
-  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
-  gem 'listen', '~> 3.0.6'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.8', '< 2.0'])
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-logrotate",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "author": "SIMP Team",
   "summary": "configure SIMP logrotate",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,31 @@
+HOSTS:
+  el7:
+    roles:
+      - default
+      - node
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/352C64E5.txt
+
+  el6:
+    roles:
+      - node
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/0608B895.txt
+
+CONFIG:
+  log_level: verbose
+  type:      aio
+  vagrant_memsize: 256
+  ## vb_gui: true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,24 +1,99 @@
 require 'spec_helper'
 
 describe 'logrotate' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) { facts }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
 
+      context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('logrotate') }
-        it { is_expected.to create_file('/etc/logrotate.conf').with_content(/weekly/) }
-        it { is_expected.to create_file('/etc/logrotate.d').with_ensure('directory') }
-        it { is_expected.to contain_package('logrotate').with_ensure('installed') }
 
-        context "dateext set to false" do
-          let(:params) {{
-            :dateext => false
-          }}
-
-          it { is_expected.to create_file('/etc/logrotate.conf').with_content(/nodateext/)}
+        it do
+          is_expected.to create_file('/etc/logrotate.simp.d').with( {
+           :ensure   => 'directory',
+           :owner    => 'root',
+           :group    => 'root',
+           :recurse  => true,
+           :purge    => true,
+           :force    => true,
+           :mode     => '0750'
+          } )
         end
+
+        it do
+          expected = <<EOM
+# This file managed by puppet.
+# Any changes that you make will be reverted on the next puppet run.
+
+weekly
+rotate 4
+create
+compress
+dateext
+dateformat -%Y%m%d.%s
+include /etc/logrotate.simp.d
+include /etc/logrotate.d
+
+
+/var/log/wtmp {
+    monthly
+    minsize 1M
+    create 0664 root utmp
+    rotate 1
+}
+EOM
+          is_expected.to create_file('/etc/logrotate.conf').with_content(expected)
+        end
+
+
+        it { is_expected.to contain_package('logrotate').with_ensure('installed') }
+      end
+
+      context 'create set to false' do
+        let(:params) {{ :create => false }}
+
+        it { is_expected.to_not create_file('/etc/logrotate.conf').with_content(/^create/) }
+      end
+
+      context 'compress set to false' do
+        let(:params) {{ :compress => false }}
+
+        it { is_expected.to_not create_file('/etc/logrotate.conf').with_content(/compress/) }
+      end
+
+      context 'dateext set to false' do
+        let(:params) {{ :dateext => false }}
+
+        it { is_expected.to create_file('/etc/logrotate.conf').with_content(/nodateext/) }
+      end
+
+      context 'minsize set' do
+        let(:params) {{ :minsize => '1M' }}
+
+        it { is_expected.to create_file('/etc/logrotate.conf').with_content(/minsize 1M/) }
+      end
+
+      context 'maxsize set' do
+        let(:params) {{ :maxsize => '1G' }}
+
+        it { is_expected.to create_file('/etc/logrotate.conf').with_content(/maxsize 1G/) }
+      end
+
+      context 'both minsize and maxsize set' do
+        let(:params) {{
+          :minsize => '1M',
+          :maxsize => '1G'
+        }}
+
+        it { is_expected.to create_file('/etc/logrotate.conf').with_content(/minsize 1M/) }
+        it { is_expected.to_not create_file('/etc/logrotate.conf').with_content(/maxsize 1G/) }
+      end
+
+      context 'manage_wtmp set to false' do
+        let(:params) {{ :manage_wtmp => false }}
+
+        it { is_expected.to_not create_file('/etc/logrotate.conf').with_content(%r(/var/log/wtmp {)) }
       end
     end
   end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -14,8 +14,8 @@ describe 'logrotate::rule' do
             :log_files => ['test1.log', 'test2.log']
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
-          it { is_expected.to_not create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction/) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
+          it { is_expected.to_not create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction/) }
         end
 
         context 'without a lastaction specified and lastaction_restart_logger = true' do
@@ -24,12 +24,12 @@ describe 'logrotate::rule' do
             :lastaction_restart_logger => true
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/test1\.log.*test2\.log/) }
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
             if (facts[:operatingsystemmajrelease].to_s >= '7')
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart rsyslog/m) }
+              it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart rsyslog/m) }
             else
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service rsyslog restart/m) }
+              it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service rsyslog restart/m) }
             end
           end
         end
@@ -42,9 +42,9 @@ describe 'logrotate::rule' do
           let(:hieradata) { 'alternate_logger' }
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
             if (facts[:operatingsystemmajrelease].to_s >= '7')
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart syslog/m) }
+              it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+\/usr\/bin\/systemctl restart syslog/m) }
             else
-              it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service syslog restart/m) }
+              it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+\/sbin\/service syslog restart/m) }
             end
           end
         end
@@ -55,7 +55,7 @@ describe 'logrotate::rule' do
             :lastaction  => 'this is a lastaction'
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
         end
         context 'with default params' do
           let(:params) {{
@@ -63,8 +63,8 @@ describe 'logrotate::rule' do
           }}
           let(:pre_condition) { 'include "logrotate"' }
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*dateext\n/m) }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*rotate\s+4\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/^\s*dateext\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/^\s*rotate\s+4\n/m) }
         end
         context 'with non default parameters' do
           let(:params) {{
@@ -73,8 +73,8 @@ describe 'logrotate::rule' do
             :rotate    => 5
           }}
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*nodateext\n/m) }
-          it { is_expected.to create_file('/etc/logrotate.d/test_logrotate_title').with_content(/^\s*rotate\s+5\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/^\s*nodateext\n/m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/^\s*rotate\s+5\n/m) }
         end
       end
     end


### PR DESCRIPTION
Move SIMP-specific logrotate rules to a SIMP-managed configuration
directory, /etc/logrotate.simp.d, and ensure logrotate processes
that directory first. This ensures SIMP rules take priority, when
duplicate rules are specified.

Also add an acceptance test.

SIMP-4979 #close