### PR TITLE
(SIMP-MAINT) Fix bad changelog date order

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Sat Mar 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.1-0
+* Mon Jul 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.1-0
 - Added OEL and Puppet 5 support
 
 * Mon Jul 02 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.0-0


### PR DESCRIPTION
The CHANGELOG entries were not cronological.  This error
was picked up by our linters, when the appropriate version
of simp-rake-helpers was pulled in by the Travis cron job.
https://travis-ci.org/simp/pupmod-simp-logrotate/jobs/422289140