### PR TITLE
(SIMP-7230) Fix size entries in logrotate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Jan 03 2020 Jeanne Greulich <jeanne,greulich@onyxpoint.com> - 6.5.0-0
+- Create size type that allows integers and pattern that allows k,M, or G
+  suffix.
+- Change type for minsize, maxsize and size values to use the above type.
+- Remove duplicate entry for size in conf.erb and add maxsize type.
+- Update spec_helper.rb
+
 * Thu Dec 19 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.0-0
 - Add EL8 support
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 * Fri Jan 03 2020 Jeanne Greulich <jeanne,greulich@onyxpoint.com> - 6.5.0-0
-- Create size type that allows integers and pattern that allows k,M, or G
-  suffix.
-- Change type for minsize, maxsize and size values to use the above type.
-- Remove duplicate entry for size in conf.erb and add maxsize type.
-- Update spec_helper.rb
+- Allow all log size configuration parameters to be specified in bytes,
+  kilobytes, megabytes, or gigabytes.
+- Fixed a bug in which the size parameter in the global logrotate configuration
+  file was specified more than once.
+- Added ability to specify maxsize configuration for specific log rotate rules.
 
 * Thu Dec 19 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.0-0
 - Add EL8 support

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,7 +14,7 @@
 **Data types**
 
 * [`Logrotate::Periods`](#logrotateperiods): Allowed time intervals for logrotate
-* [`Logrotate::Size`](#logrotatesize): Valid size of a log in either bytes (no suffix) or k, M, G for kilobytes, Megabytes or Gigabtes
+* [`Logrotate::Size`](#logrotatesize): Size of a log in bytes, kilobytes, megabytes or gigabytes
 
 ## Classes
 
@@ -517,8 +517,7 @@ Alias of `Enum['hourly', 'daily', 'weekly', 'monthly', 'yearly']`
 
 ### Logrotate::Size
 
-Valid size of a log in either bytes (no suffix) or
-k, M, G for kilobytes, Megabytes or Gigabtes
+Size of a log in bytes, kilobytes, megabytes or gigabytes
 
-Alias of `Variant[Integer[1], Pattern[/^[0-9]+[kGM]?$/]]`
+Alias of `Variant[Integer[1], Pattern[/^[0-9]+[kMG]?$/]]`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11,6 +11,11 @@
 
 * [`logrotate::rule`](#logrotaterule): Add a LogRotate Configuration  If options have a 'no' variant, then the no variant will be set if you set the primary value to false  The ``l
 
+**Data types**
+
+* [`Logrotate::Periods`](#logrotateperiods): Allowed time intervals for logrotate
+* [`Logrotate::Size`](#logrotatesize): Valid size of a log in either bytes (no suffix) or k, M, G for kilobytes, Megabytes or Gigabtes
+
 ## Classes
 
 ### logrotate
@@ -113,7 +118,7 @@ Default value: `undef`
 
 ##### `maxsize`
 
-Data type: `Optional[Pattern['^\d+(k|M|G)?$']]`
+Data type: `Optional[Logrotate::Size]`
 
 The default maximum size of a logfile
 
@@ -121,7 +126,7 @@ Default value: `undef`
 
 ##### `minsize`
 
-Data type: `Optional[Pattern['^\d+(k|M|G)?$']]`
+Data type: `Optional[Logrotate::Size]`
 
 The default minimum size of a logfile
 
@@ -335,9 +340,17 @@ Data type: `Optional[Integer[0]]`
 
 Default value: `undef`
 
+##### `maxsize`
+
+Data type: `Optional[Logrotate::Size]`
+
+
+
+Default value: `undef`
+
 ##### `minsize`
 
-Data type: `Optional[Integer[0]]`
+Data type: `Optional[Logrotate::Size]`
 
 
 
@@ -423,7 +436,7 @@ Default value: `undef`
 
 ##### `size`
 
-Data type: `Optional[Integer[0]]`
+Data type: `Optional[Logrotate::Size]`
 
 
 
@@ -493,4 +506,19 @@ Data type: `Optional[Array[String[1]]]`
 
 
 Default value: `undef`
+
+## Data types
+
+### Logrotate::Periods
+
+Allowed time intervals for logrotate
+
+Alias of `Enum['hourly', 'daily', 'weekly', 'monthly', 'yearly']`
+
+### Logrotate::Size
+
+Valid size of a log in either bytes (no suffix) or
+k, M, G for kilobytes, Megabytes or Gigabtes
+
+Alias of `Variant[Integer[1], Pattern[/^[0-9]+[kGM]?$/]]`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,8 +72,8 @@ class logrotate (
   Boolean                            $dateext        = true,
   String[1]                          $dateformat     = '-%Y%m%d.%s',
   Optional[Boolean]                  $dateyesterday  = undef,
-  Optional[Pattern['^\d+(k|M|G)?$']] $maxsize        = undef,
-  Optional[Pattern['^\d+(k|M|G)?$']] $minsize        = undef,
+  Optional[Logrotate::Size]          $maxsize        = undef,
+  Optional[Logrotate::Size]          $minsize        = undef,
   String[1]                          $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String[1]                          $logger_service = 'rsyslog'
 ) {

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -43,6 +43,7 @@
 #   If false, mailfirst will be set. Ignored if $mail is `false`
 #
 # @param maxage
+# @param maxsize
 # @param minsize
 # @param missingok
 # @param olddir
@@ -100,7 +101,8 @@ define logrotate::rule (
   Optional[Simplib::EmailAddress] $mail                      = undef,
   Boolean                         $maillast                  = true,
   Optional[Integer[0]]            $maxage                    = undef,
-  Optional[Integer[0]]            $minsize                   = undef,
+  Optional[Logrotate::Size]       $maxsize                   = undef,
+  Optional[Logrotate::Size]       $minsize                   = undef,
   Boolean                         $missingok                 = false,
   Optional[Stdlib::Absolutepath]  $olddir                    = undef,
   Optional[String[1]]             $postrotate                = undef,
@@ -110,7 +112,7 @@ define logrotate::rule (
   Boolean                         $lastaction_restart_logger = false,
   Optional[String[1]]             $logger_service            = simplib::lookup('logrotate::logger_service', {'default_value' => 'rsyslog'}),
   Optional[Integer[0]]            $rotate                    = undef,
-  Optional[Integer[0]]            $size                      = undef,
+  Optional[Logrotate::Size]       $size                      = undef,
   Boolean                         $sharedscripts             = true,
   Optional[Boolean]               $shred                     = undef,
   Optional[Integer[0]]            $shredcycles               = undef,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -78,7 +78,7 @@
 # @param su_group
 # @param tabooext
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-logrotate/graphs/contributors
 #
 define logrotate::rule (
   Array[String[1]]                $log_files,

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -54,6 +54,19 @@ describe 'logrotate::rule' do
         it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/lastaction\n\s+this is a lastaction/m) }
       end
 
+      context 'with a lastaction specified' do
+        let(:params) {{
+          :log_files  => ['test1.log', 'test2.log'],
+          :size  => 1000000,
+          :minsize =>  '20k',
+          :maxsize =>  '1G'
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/size\s1000000/) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/minsize\s20k/) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(/maxsize\s1G/) }
+      end
+
       context 'with default params' do
         let(:params) {{
           :log_files => ['test1.log', 'test2.log'],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,8 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
+    # ensure the system can run on FIPS systems
+    Puppet[:digest_algorithm] = 'sha256'
 
     # sanitize hieradata
     if defined?(hieradata)

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -68,6 +68,9 @@
 <%  if @maxage -%>
     maxage <%= @maxage %>
 <%  end -%>
+<%  if @maxsize -%>
+    maxsize <%= @maxsize %>
+<%  end -%>
 <%  if @minsize -%>
     minsize <%= @minsize %>
 <%  end -%>
@@ -102,9 +105,6 @@
     endscript
 <%  end -%>
     rotate <%= @_rotate.to_s %>
-<%  if @size -%>
-    size <%= @size %>
-<%  end -%>
 <%  if @sharedscripts -%>
     sharedscripts
 <%  else -%>

--- a/types/periods.pp
+++ b/types/periods.pp
@@ -1,3 +1,4 @@
+# Allowed time intervals for logrotate
 type Logrotate::Periods = Enum[
   'hourly',
   'daily',

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,0 +1,3 @@
+# Valid size of a log in either bytes (no suffix) or
+# k, M, G for kilobytes, Megabytes or Gigabtes
+type Logrotate::Size = Variant[ Integer[1], Pattern[/^[0-9]+[kGM]?$/]]

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,3 +1,2 @@
-# Valid size of a log in either bytes (no suffix) or
-# k, M, G for kilobytes, Megabytes or Gigabtes
-type Logrotate::Size = Variant[ Integer[1], Pattern[/^[0-9]+[kGM]?$/]]
+# Size of a log in bytes, kilobytes, megabytes or gigabytes
+type Logrotate::Size = Variant[ Integer[1], Pattern[/^[0-9]+[kMG]?$/]]


### PR DESCRIPTION
- Allow all log size configuration parameters to be specified in bytes,
  kilobytes, megabytes, or gigabytes.
- Fixed a bug in which the size parameter in the global logrotate configuration
  file was specified more than once.
- Added ability to specify maxsize configuration for specific log rotate rules.
- Updated spec_helper.rb to allow spec test to run on FIPS-enabled server

SIMP-7231 #close
SIMP-7230 #close
SIMP-7422 #close
SIMP-7423 #close
SIMP-7367 #close