### PR TITLE
Ignore duplicate entries and add ordering to simp entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 7.1.0
+- Add `logrotate::rule::order` (default `'50'`) to control the order in which
+  SIMP entries are processed. Managed rule files are now written as
+  `${logrotate::configdir}/${order}-${name}` instead of `${name}`, so SIMP
+  rules sort deterministically ahead of overlapping system rules (#111).
+- Emit the `ignoreduplicates` directive in SIMP rules so that duplicate
+  `/etc/logrotate.d` entries for the same log file are silently skipped
+  rather than causing a "duplicate log entry" error (#111).
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 7.0.1
 - Resolved puppet-lint manifest whitespace offenses
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,13 @@
 # @param configdir
 #   The primary directory for SIMP-managed configuration files.
 #
+#   * Listed first in ``logrotate.conf`` so that rules placed here are
+#     processed before any in ``$include_dirs`` and, in combination with
+#     the ``ignoreduplicates`` directive set by ``logrotate::rule``, take
+#     priority over overlapping entries in those directories.
+#
 # @param include_dirs
-#   Directories to include in your logrotate configuration
+#   Additional directories to include in your logrotate configuration
 #
 #   * ``$logrotate::configdir`` is always included and is listed first
 #   * Be sure to include ``/etc/logrotate.d`` in this list if you
@@ -91,7 +96,8 @@ class logrotate (
     content => template("${module_name}/logrotate.conf.erb")
   }
 
-  # This is where the custom rules will go. They will be purged if not managed!
+  # SIMP owns this directory exclusively, so files not managed by puppet
+  # are purged.
   file { $configdir:
     ensure  => 'directory',
     owner   => 'root',

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -34,6 +34,19 @@
 # @param extension
 # @param ifempty
 #
+# @param ignoreduplicates
+#   Add the ``ignoreduplicates`` directive so that this rule causes
+#   logrotate to skip any subsequent matches for the same log files
+#   declared in later-processed configuration files
+#
+# @param order
+#   String prefix used to determine the order in which logrotate
+#   processes this file within ``$logrotate::configdir``
+#
+#   * Logrotate processes files in the directory in alphabetical order,
+#     so lower values are processed first
+#   * The resulting filename will be ``${order}-${name}``
+#
 # @param ext_include
 #   Corresponds to the ``include`` logrotate configuration since it is a
 #   reserved word in Puppet
@@ -97,6 +110,8 @@ define logrotate::rule (
   Optional[Boolean]               $delaycompress             = undef,
   Optional[String[1]]             $extension                 = undef,
   Boolean                         $ifempty                   = false,
+  Boolean                         $ignoreduplicates          = true,
+  Pattern[/\A\d+\z/]              $order                     = '50',
   Optional[Array[String[1]]]      $ext_include               = undef,
   Optional[Simplib::EmailAddress] $mail                      = undef,
   Boolean                         $maillast                  = true,
@@ -161,7 +176,7 @@ define logrotate::rule (
     undef   => $logrotate::rotate,
   default => $rotate }
 
-  file { "${logrotate::configdir}/${name}":
+  file { "${logrotate::configdir}/${order}-${name}":
     owner   => 'root',
     group   => 'root',
     mode    => '0644',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-logrotate",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "author": "SIMP Team",
   "summary": "configure SIMP logrotate",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -68,14 +68,12 @@ describe 'logrotate class' do
       end
 
       it 'logrotate should use SIMP rule in lieu of overlapping system rule' do
-        # make sure our assumptions about the default rule are correct
-        result = on(host, 'grep -l /var/log/messages /etc/logrotate.d/*')
-
-        expect(result.stdout.split("\n").first.strip).not_to match(%r{^compress})
-
+        # the SIMP rule is processed first (alphabetical order) and uses
+        # ignoreduplicates, so the system /etc/logrotate.d/syslog entry for
+        # the same log file is silently skipped
         result = on(host, 'logrotate -f /etc/logrotate.conf', accept_all_exit_codes: true)
 
-        expect(result.stderr).to include('duplicate log entry for /var/log/messages')
+        expect(result.stderr).not_to match(%r{duplicate log entry for /var/log/messages})
         on(host, 'ls -l /var/log/messages*')
         on(host, 'ls -l /var/log/messages-[0-9]*\.[0-9]*\.gz')
       end

--- a/spec/defines/expected/rule.txt
+++ b/spec/defines/expected/rule.txt
@@ -2,6 +2,7 @@
 # Any changes that you make will be reverted on the next puppet run.
 
 "test1.log" "test2.log"  {
+    ignoreduplicates
     compress
     nodelaycompress
     nocopy

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -16,8 +16,8 @@ describe 'logrotate::rule' do
         let(:content) { File.read('spec/defines/expected/rule.txt') }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(content) }
-        it { is_expected.not_to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(content) }
+        it { is_expected.not_to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction}) }
       end
 
       context 'without a lastaction specified and lastaction_restart_logger = true' do
@@ -29,11 +29,11 @@ describe 'logrotate::rule' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{test1\.log.*test2\.log}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{test1\.log.*test2\.log}) }
         if ((facts[:operatingsystem] == 'Amazon') && (facts[:operatingsystemmajrelease].to_i < 3)) || (facts[:operatingsystemmajrelease].to_i >= 7)
-          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction\n\s+/usr/bin/systemctl restart rsyslog}m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction\n\s+/usr/bin/systemctl restart rsyslog}m) }
         else
-          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction\n\s+/sbin/service rsyslog restart}m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction\n\s+/sbin/service rsyslog restart}m) }
         end
       end
 
@@ -47,9 +47,9 @@ describe 'logrotate::rule' do
         let(:hieradata) { 'alternate_logger' }
 
         if ((facts[:operatingsystem] == 'Amazon') && (facts[:operatingsystemmajrelease].to_i < 3)) || (facts[:operatingsystemmajrelease].to_i >= 7)
-          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction\n\s+/usr/bin/systemctl restart syslog}m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction\n\s+/usr/bin/systemctl restart syslog}m) }
         else
-          it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction\n\s+/sbin/service syslog restart}m) }
+          it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction\n\s+/sbin/service syslog restart}m) }
         end
       end
 
@@ -62,7 +62,7 @@ describe 'logrotate::rule' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{lastaction\n\s+this is a lastaction}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{lastaction\n\s+this is a lastaction}m) }
       end
 
       context 'with a lastaction specified' do
@@ -76,9 +76,9 @@ describe 'logrotate::rule' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{size\s1000000}) }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{minsize\s20k}) }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{maxsize\s1G}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{size\s1000000}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{minsize\s20k}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{maxsize\s1G}) }
       end
 
       context 'with default params' do
@@ -90,8 +90,8 @@ describe 'logrotate::rule' do
         let(:pre_condition) { 'include "logrotate"' }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{^\s*dateext\n}m) }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{^\s*rotate\s+4\n}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{^\s*dateext\n}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{^\s*rotate\s+4\n}m) }
       end
 
       context 'with non default parameters' do
@@ -104,8 +104,8 @@ describe 'logrotate::rule' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{^\s*nodateext\n}m) }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{^\s*rotate\s+5\n}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{^\s*nodateext\n}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{^\s*rotate\s+5\n}m) }
       end
 
       context 'with su features' do
@@ -119,7 +119,7 @@ describe 'logrotate::rule' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{^\s*su httpd httpd\n}m) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{^\s*su httpd httpd\n}m) }
       end
 
       context 'dateyesterday set to true' do
@@ -130,7 +130,7 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{dateyesterday}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{dateyesterday}) }
       end
 
       context 'dateyesterday set to false' do
@@ -141,7 +141,7 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').without_content(%r{dateyesterday}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').without_content(%r{dateyesterday}) }
       end
 
       context 'shred set to true' do
@@ -152,7 +152,7 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{shred\n}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{shred\n}) }
       end
 
       context 'shred set to true and shredcycles set' do
@@ -164,8 +164,8 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{shred\n}) }
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{shredcycles 5}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{shred\n}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{shredcycles 5}) }
       end
 
       context 'shred set to false' do
@@ -176,7 +176,7 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{noshred}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{noshred}) }
       end
 
       context 'shred set to false and shredcycles set' do
@@ -188,9 +188,9 @@ describe 'logrotate::rule' do
           }
         end
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').with_content(%r{noshred}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').with_content(%r{noshred}) }
 
-        it { is_expected.to create_file('/etc/logrotate.simp.d/test_logrotate_title').without_content(%r{shredcycles 5}) }
+        it { is_expected.to create_file('/etc/logrotate.simp.d/50-test_logrotate_title').without_content(%r{shredcycles 5}) }
       end
     end
   end

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -2,6 +2,9 @@
 # Any changes that you make will be reverted on the next puppet run.
 
 <% Array(@log_files).each do |_file| -%>"<%= _file %>" <% end -%> {
+<%  if @ignoreduplicates -%>
+    ignoreduplicates
+<%  end -%>
 <%  unless @_compress -%>
     nocompress
 <%  else -%>


### PR DESCRIPTION
Use the ignoreduplicates setting to allow simp managed rules to take priority over on-system rules. Add a basic ordering mechanism for simp based rules.

Fix #111 